### PR TITLE
chore(workflows/main.yml): go-version 1.20.7 -> 1.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.18'
       - run: go version
 
       - name: Check our repo


### PR DESCRIPTION
match go version to version used by alertmanager: https://github.com/prometheus/alertmanager/blob/d7b4f0c7322e7151d6e3b1e31cbc15361e295d8d/go.mod#L3